### PR TITLE
添加 Windows 下安装 lxml 的说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
         ```
     * Windows
 
-        Windows 下使用 pip 安装 lxml 时编译无法通过，到 <https://pypi.python.org/pypi/lxml/3.5.0> 下载对应自己 Python 版本 32 或 64 位 exe 文件安装即可。
+        Windows 下使用 pip 安装 lxml 时编译无法通过，到 <https://pypi.python.org/pypi/lxml/3.5.0> 下载对应自己 Python 版本的 32 或 64 位 exe 文件安装即可。
 
 2. 登录多说后台，在`http://<shortname>.duoshuo.com/admin/tools/` 页面导出多说评论
     ![export_duoshuo](screenshot/duoshuo_export.png)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@
 
 1. 下载 [duoshuo-migrator.py](./duoshuo-migrator.py?raw=true)，并安装依赖
 
-    ```bash
-    pip install lxml
-    ```
+    * Linux/Mac OS X
+
+        ```bash
+        pip install lxml
+        ```
+    * Windows
+
+        Windows 下使用 pip 安装 lxml 时编译无法通过，到 <https://pypi.python.org/pypi/lxml/3.5.0> 下载对应自己 Python 版本 32 或 64 位 exe 文件安装即可。
 
 2. 登录多说后台，在`http://<shortname>.duoshuo.com/admin/tools/` 页面导出多说评论
     ![export_duoshuo](screenshot/duoshuo_export.png)


### PR DESCRIPTION
在 Windows 下直接使用 `pip install lxml` 会报错：

```
src\lxml\includes\etree_defs.h(14) : fatal error C1083: Cannot open include file: 'libxml/xmlversion.h': No such file or directory
Compile failed: command 'D:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\BIN\\cl.exe' failed with exit status 2
creating system~2
creating system~2\temp
D:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\cl.exe /c /nologo /Ox /MD /W3 /GS- /DNDEBUG -I/usr/include/libxml2 /Tce:\system~2\temp\xmlXPathInitbqqssr.c /Fosystem~2\temp\xmlXPathInitbqqssr.obj
xmlXPathInitbqqssr.c
e:\system~2\temp\xmlXPathInitbqqssr.c(1) : fatal error C1083: Cannot open include file: 'libxml/xpath.h': No such file or directory
*********************************************************************************
Could not find function xmlCheckVersion in library libxml2. Is libxml2 installed?
*********************************************************************************
error: command 'D:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\BIN\\cl.exe' failed with exit status 2
```

可以通过直接安装 pypi 上提供的 exe 解决。