### PR TITLE
fix File "duoshuo-migrator.py", line 53, in json2objects     link = art['url'] KeyError: 'url'

### DIFF
--- a/duoshuo-migrator.py
+++ b/duoshuo-migrator.py
@@ -48,14 +48,15 @@ def json2objects(json_obj):
     for art in articles:
         id = int(art['thread_id'])
         title = art['title']
-        link = art['url']
-        identifier = str(id)
-        if 'thread_key' in art and \
-           art['thread_key'] is not None and \
-           art['thread_key'].strip() != "":
-            identifier = art['thread_key']
+        if art.has_key('url'):
+            link = art['url']
+            identifier = str(id)
+            if 'thread_key' in art and \
+               art['thread_key'] is not None and \
+               art['thread_key'].strip() != "":
+                identifier = art['thread_key']
 
-        id_to_article[id] = Article(id, title, link, identifier, 'open')
+            id_to_article[id] = Article(id, title, link, identifier, 'open')
     
     for cmnt in comments:
         article_id = cmnt['thread_id']


### PR DESCRIPTION
Traceback (most recent call last):
  File "duoshuo-migrator.py", line 155, in <module>
    main()
  File "duoshuo-migrator.py", line 146, in main
    articles = json2objects(data)
  File "duoshuo-migrator.py", line 53, in json2objects
    link = art['url']
KeyError: 'url'

有些文章没有URL，需要对数据做个清理，或者加个判断